### PR TITLE
remove redundant memset

### DIFF
--- a/iguana/dpow/dpow_fsm.c
+++ b/iguana/dpow/dpow_fsm.c
@@ -295,7 +295,6 @@ void dpow_statemachinestart(void *ptr)
     if ( strcmp(src->symbol,"KMD") == 0 )
     {
         MoMdepth = 0;
-        memset(&MoM,0,sizeof(MoM));
         kmdheight = checkpoint.blockhash.height;
     }
     else if ( strcmp(dest->symbol,"KMD") == 0 )


### PR DESCRIPTION
- Removal of memset(&MoM,0,sizeof(MoM)); at line 298 because it is performed at line 293.